### PR TITLE
Add JUnit 5 test cases for Train test class  #13

### DIFF
--- a/src/test/java/TrainTest.java
+++ b/src/test/java/TrainTest.java
@@ -1,0 +1,66 @@
+import com.anupam1897.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TrainTest {
+
+    private Train train;
+
+    @BeforeEach
+    void setUp() {
+        train = new Train("Express", "T101");
+    }
+
+    // ── Test 1: Train created with correct model ───────────────────
+    @Test
+    void testTrainModel() {
+        assertEquals("Express", train.getModel());
+    }
+
+    // ── Test 2: Train created with correct ID ─────────────────────
+    @Test
+    void testTrainId() {
+        assertEquals("T101", train.getTrainId());
+    }
+
+    // ── Test 3: toString contains train ID ────────────────────────
+    @Test
+    void testToStringContainsTrainId() {
+        assertTrue(train.toString().contains("T101"));
+    }
+
+    // ── Test 4: toString contains model ───────────────────────────
+    @Test
+    void testToStringContainsModel() {
+        assertTrue(train.toString().contains("Express"));
+    }
+
+    // ── Test 5: toString correct format ───────────────────────────
+    @Test
+    void testToStringFormat() {
+        assertEquals("Train[T101] - Express", train.toString());
+    }
+
+    // ── Test 6: Two trains have different IDs ─────────────────────
+    @Test
+    void testTwoTrainsHaveDifferentIds() {
+        Train train2 = new Train("Superfast", "T202");
+        assertNotEquals(train.getTrainId(), train2.getTrainId());
+    }
+
+    // ── Test 7: Two trains have different models ───────────────────
+    @Test
+    void testTwoTrainsHaveDifferentModels() {
+        Train train2 = new Train("Superfast", "T202");
+        assertNotEquals(train.getModel(), train2.getModel());
+    }
+
+    // ── Test 8: Train with same ID and model are equal in values ──
+    @Test
+    void testTrainValuesMatch() {
+        Train train2 = new Train("Express", "T101");
+        assertEquals(train.getModel(),   train2.getModel());
+        assertEquals(train.getTrainId(), train2.getTrainId());
+    }
+}


### PR DESCRIPTION
## Summary
Add unit tests for the Train class covering creation,
getters and toString behaviours.

## Changes
- Added `TrainTest.java` with 8 test cases

## Test Cases
| Test | Description |
|---|---|
| testTrainModel | Model stored correctly |
| testTrainId | Train ID stored correctly |
| testToStringContainsTrainId | toString includes train ID |
| testToStringContainsModel | toString includes model name |
| testToStringFormat | toString matches exact format |
| testTwoTrainsHaveDifferentIds | Two trains have independent IDs |
| testTwoTrainsHaveDifferentModels | Two trains have independent models |
| testTrainValuesMatch | Same values produce matching getters |